### PR TITLE
Port to v0.12+, newSession now has a callback

### DIFF
--- a/lib/cluster-store.js
+++ b/lib/cluster-store.js
@@ -24,8 +24,8 @@ function installSessionHandler(tlsServer, namespace) {
       'Set a unique namespace in the session-sharing initialization.');
   }
 
-  tlsServer.on('newSession', function(sessionId, sessionData) {
-    onNewSession(namespace, sessionId, sessionData);
+  tlsServer.on('newSession', function(sessionId, sessionData, callback) {
+    onNewSession(namespace, sessionId, sessionData, callback);
   });
 
   tlsServer.on('resumeSession', function(sessionId, callback) {
@@ -40,10 +40,13 @@ function installSessionHandler(tlsServer, namespace) {
  * @param {String} namespace The namespace used to store the session data.
  * @param {Buffer} sessionId The id used to identify the session.
  * @param {Buffer} sessionData The data describing the session state.
+ * @param {Function} callback Callback, only for node >= 0.12, must be called.
  * @private
  */
-function onNewSession(namespace, sessionId, sessionData) {
-  collection.set(createKey(namespace, sessionId), encode(sessionData));
+function onNewSession(namespace, sessionId, sessionData, callback) {
+  var key = createKey(namespace, sessionId)
+  var value = encode(sessionData);
+  collection.set(key, value, callback);
 }
 
 /**


### PR DESCRIPTION
The callback is mandatory, a fairly breaking API change, I'm hoping its
mentioned somewhere.